### PR TITLE
[FEAT] : Implement In-Place Editing for PDF Metadata and AI Tags

### DIFF
--- a/src/components/pdfView/MetadataDropdown.tsx
+++ b/src/components/pdfView/MetadataDropdown.tsx
@@ -6,9 +6,10 @@ import type { Metadata } from "@/lib/api";
 
 type Props = {
   metadata: Metadata;
+  onSave: (newMetadata: Metadata) => void;
 }
 
-export default function MetadataDropdown({ metadata }: Props) {
+export default function MetadataDropdown({ metadata, onSave }: Props) {
   const [isOpen, setIsOpen] = useState(false)
 
   return (
@@ -24,9 +25,11 @@ export default function MetadataDropdown({ metadata }: Props) {
           <ChevronDown className="h-4 w-4 text-gray-400" />
         )}
       </button>
+
       {isOpen && (
         <div className="mt-2">
-          <PDFMetadata metadata={metadata} />
+          {/* Pass onSave down to PDFMetadata */}
+          <PDFMetadata metadata={metadata} onSave={onSave} />
         </div>
       )}
     </div>

--- a/src/components/pdfView/RegionCard.tsx
+++ b/src/components/pdfView/RegionCard.tsx
@@ -1,5 +1,6 @@
 // src/components/pdfView/RegionCard.tsx
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card"
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { useState } from "react";
 
 export type Region = {
   page: number
@@ -10,35 +11,103 @@ export type Region = {
 }
 
 type Props = {
-  region: Region
+  region: Region;
+  index: number;
+  onSaveTag: (index: number, newTag: string) => void;
 }
 
-export default function RegionCard({ region }: Props) {
-  return (
-    <Card className="mb-4 bg-gray-800 text-gray-100">
-      <CardHeader className="border-b border-gray-700">
-        <CardTitle className="text-sm uppercase text-blue-400">
-          AI Tag: {region.tag}
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-2 text-xs">
-        <div>
-          <span className="font-medium text-green-300">Page:</span> {region.page}
-        </div>
-        <div>
-          <span className="font-medium text-green-300">Type:</span> {region.type}
-        </div>
-        <div>
-          <span className="font-medium text-green-300">Content:</span>
-          <p className="mt-1 px-2 py-1 bg-gray-700 rounded">{region.content}</p>
-        </div>
-        <div>
-          <span className="font-medium text-green-300">BBox:</span>
-          <code className="block mt-1 px-2 py-1 bg-gray-700 rounded">
-            [{region.bbox.map((n) => n.toFixed(1)).join(", ")}]
-          </code>
-        </div>
-      </CardContent>
-    </Card>
-  )
+// List of all valid tags for the dropdown:
+const ALL_TAGS = [
+  "title",
+  "subtitle",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "paragraph",
+  "image_caption",
+  "image",
+  "header",
+  "footer",
+  "form_label",
+  "checkbox",
+] as const;
+
+
+export default function RegionCard({ region, index, onSaveTag }: Props) {
+
+    const [editMode, setEditMode] = useState(false);
+    const [selectedTag, setSelectedTag] = useState<string>(region.tag);
+
+    const handleSave = () => {
+        onSaveTag(index, selectedTag);
+        setEditMode(false);
+    };
+
+
+    return (
+        <Card className="mb-4 bg-gray-800 text-gray-100">
+        <CardHeader className="border-b border-gray-700 flex justify-between items-center">
+            <CardTitle className="text-sm uppercase text-blue-400">
+            AI Tag:
+            {editMode ? (
+                <select
+                className="ml-2 bg-gray-700 text-white text-xs rounded px-2 py-1"
+                value={selectedTag}
+                onChange={(e) => setSelectedTag(e.target.value)}
+                >
+                {ALL_TAGS.map((t) => (
+                    <option key={t} value={t}>
+                    {t}
+                    </option>
+                ))}
+                </select>
+            ) : (
+                <span className="ml-1">{region.tag}</span>
+            )}
+            </CardTitle>
+
+            {editMode ? (
+            <button
+                onClick={handleSave}
+                className="text-sm text-green-300 hover:underline"
+            >
+                Save
+            </button>
+            ) : (
+            <button
+                onClick={() => setEditMode(true)}
+                className="text-sm text-blue-300 hover:underline"
+            >
+                Edit
+            </button>
+            )}
+        </CardHeader>
+
+        <CardContent className="space-y-2 text-xs">
+            <div>
+            <span className="font-medium text-green-300">Page:</span>{" "}
+            {region.page}
+            </div>
+            <div>
+            <span className="font-medium text-green-300">Type:</span>{" "}
+            {region.type}
+            </div>
+            <div>
+            <span className="font-medium text-green-300">Content:</span>
+            <p className="mt-1 px-2 py-1 bg-gray-700 rounded">
+                {region.content}
+            </p>
+            </div>
+            <div>
+            <span className="font-medium text-green-300">BBox:</span>
+            <code className="block mt-1 px-2 py-1 bg-gray-700 rounded">
+                [{region.bbox.map((n) => n.toFixed(1)).join(", ")}]
+            </code>
+            </div>
+        </CardContent>
+        </Card>
+    );
 }

--- a/src/components/pdfView/pdfView.tsx
+++ b/src/components/pdfView/pdfView.tsx
@@ -6,15 +6,19 @@ import RegionCard from "./RegionCard"
 import type { Region } from "./RegionCard"
 
 type Props = {
-  data: TagResponse | null
-  loading: boolean
-}
+  data: TagResponse | null;
+  loading: boolean;
+  onUpdateRegionTag: (index: number, newTag: string) => void;
+};
 
-export default function PDFView({ data, loading }: Props) {
+export default function PDFView({ 
+  data,
+  loading,
+  onUpdateRegionTag}: Props) {
 
   console.log("PDFView loading:", loading)
   if (loading) {
-    console.log("I was here")
+    console.log("I was here in loading")
     return (
      <div className="p-6 bg-black rounded-2xl shadow-lg border border-gray-800 flex flex-col gap-2 min-h-[100px]">
        <Skeleton className="h-6 w-1/3 bg-gray-200/70 animate-pulse" />
@@ -37,8 +41,13 @@ export default function PDFView({ data, loading }: Props) {
   return (
     <div className="p-6 bg-gray-900 rounded-2xl shadow-lg border border-gray-700 overflow-auto max-h-[80vh]">
       {data.structure.map((r: Region, idx: number) => (
-        <RegionCard key={idx} region={r} />
+        <RegionCard
+          key={idx}
+          region={r}
+          index={idx}
+          onSaveTag={onUpdateRegionTag}
+        />
       ))}
     </div>
-  )
+  );
 }

--- a/src/pages/AIpdfTagger/AIpdfTagger.tsx
+++ b/src/pages/AIpdfTagger/AIpdfTagger.tsx
@@ -2,14 +2,15 @@
 import { useState } from "react"
 import AIPDFConfiguration from "@/components/AIpdfConfiguration/AIpdfConfiguration"
 import PDFView from "@/components/pdfView/pdfView"
-import PDFMetadata from "@/components/pdfView/PDFMetadata"
-import type { TagResponse } from "@/lib/api"
+import MetadataDropdown from "@/components/pdfView/MetadataDropdown"
+import type { TagResponse, Metadata, } from "@/lib/api"
 import { uploadPdf }        from "@/lib/api"
 
 export default function AIpdfTagger() {
   const [tags, setTags]       = useState<TagResponse | null>(null)
   const [loading, setLoading] = useState(false)
 
+  // 1. Handling the initial upload & AI‐tag request
   const handleUploadAndTag = async (file: File) => {
     setLoading(true)
     try {
@@ -22,6 +23,29 @@ export default function AIpdfTagger() {
       setLoading(false)
     }
   }
+
+  // 2. When PDFMetadata child saves new metadata, update in state
+  const handleUpdateMetadata = (newMetadata: Metadata) => {
+    if (!tags) return;
+    setTags({
+      ...tags,
+      metadata: newMetadata,
+    });
+  };
+
+  // 3. When a RegionCard child saves a new tag, we need to know its index
+  const handleUpdateRegionTag = (index: number, newTag: string) => {
+    if (!tags) return;
+    const newStructure = [...tags.structure];
+    newStructure[index] = {
+      ...newStructure[index],
+      tag: newTag,
+    };
+    setTags({
+      ...tags,
+      structure: newStructure,
+    });
+  };
 
   return (
     // <div className="flex flex-col md:flex-row gap-6 p-6">
@@ -51,11 +75,16 @@ export default function AIpdfTagger() {
       <div style={{ flex: 7 }} className="flex flex-col">
         {/* Show metadata above the region cards */}
         {tags && tags.metadata && (
-          <PDFMetadata metadata={tags.metadata} />
+          <MetadataDropdown 
+              metadata={tags.metadata}
+              onSave={handleUpdateMetadata}/>
         )}
         {/* Then the region cards or skeleton */}
         <div className="flex-1 overflow-auto">
-          <PDFView data={tags} loading={loading} />
+          <PDFView 
+              data={tags}
+              loading={loading} 
+              onUpdateRegionTag={handleUpdateRegionTag} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
This PR implements the feature described in issue #5 by enabling inline editing of PDF metadata and AI-generated region tags. Users can now click “Edit” on either the metadata panel or a region card, make corrections, and click “Save” to update the UI state.  

**Closes #5**

---

## Changes
1. **AIpdfTagger.tsx**  
   - Replaced direct `<PDFMetadata>` rendering with `<MetadataDropdown metadata={…} onSave={…} />`.  
   - Passed a new callback prop `onUpdateRegionTag` into `<PDFView>`.  
   - Added `handleUpdateMetadata(newMetadata: Metadata)` to update `tags.metadata` in state.  
   - Added `handleUpdateRegionTag(index: number, newTag: string)` to update `tags.structure[index].tag` in state.

2. **MetadataDropdown.tsx**  
   - Added `onSave: (newMetadata: Metadata) => void` to `Props`.  
   - Forwarded `onSave` into `<PDFMetadata metadata={metadata} onSave={onSave} />`.  
   - Kept expand/collapse logic intact.

3. **PDFMetadata.tsx**  
   - Already accepted `metadata` and `onSave` props; no structural changes needed.  
   - Verified that `handleSave()` calls `onSave(localMeta)` and toggles `editMode`.  
   - Ensured `EDITABLE_KEYS` is typed as `keyof Pick<Metadata, …>` to avoid `any`.

4. **PDFView.tsx**  
   - Added prop `onUpdateRegionTag: (index: number, newTag: string) => void` to `Props`.  
   - When mapping over `data.structure`, now renders `<RegionCard key={…} region={…} index={idx} onSaveTag={onUpdateRegionTag} />`.

5. **RegionCard.tsx**  
   - Updated function signature to `function RegionCard({ region, index, onSaveTag }: Props)`.  
   - Added `<select>` dropdown containing all valid tags when `editMode` is active.  
   - Clicking “Save” calls `onSaveTag(index, selectedTag)` and exits edit mode.

---

## Verification Steps
1. Upload a sample PDF and confirm metadata and region cards render as before.  
2. Click **Edit** on the metadata panel:
   - Metadata fields become text inputs (Title, Author, Subject, Keywords, Creator, Producer).  
   - Modify one or more fields and click **Save**.  
   - Confirm the panel returns to display mode, showing updated values.  
3. Click **Edit** on any region card:
   - The static tag text changes to a `<select>` dropdown with all valid tags.  
   - Select a new tag value and click **Save**.  
   - Confirm the card now displays the updated tag and `tags.structure[index].tag` in application state has changed.  
4. Verify no regressions:
   - While `loading === true` or `tags === null`, ensure “Edit” buttons are hidden and the skeleton placeholder still appears.  
   - Confirm that existing styling (Tailwind/shadcn UI) remains unchanged.

---

## Additional Notes
- All tag options for the dropdown are defined in `RegionCard.tsx` as a `const` array:  

```json
[
"title", "subtitle", "h1", "h2", "h3", "h4", "h5", "h6",
"paragraph", "image_caption", "image", "header", "footer",
"form_label", "checkbox"
]
```

- No backend changes were required; all updates happen in local React state.
- Automated tests are not included in this PR. Manual QA confirmed functionality.

---

Once merged, issue #5 will be considered resolved.